### PR TITLE
docs(GraphQL): Correct Deep Mutation examples

### DIFF
--- a/wiki/content/graphql/mutations/deep.md
+++ b/wiki/content/graphql/mutations/deep.md
@@ -27,14 +27,14 @@ type Post {
 }
 ```
 
-### **Example**: Deep Deep mutation using variables
+### **Example**: Adding deep nested post with new author mutation using variables
 ```graphql
-mutation DeepAuthor($author: DeepAuthorInput!) {
-  DeepAuthor(input: [$author]) {
+mutation addAuthorWithPost($author: addAuthorInput!) {
+  addAuthor(input: [$author]) {
     author {
       id
       name
-      post {
+      posts {
         title
         text
       }
@@ -57,13 +57,13 @@ Variables:
 }
 ```
 
-### **Example**: Deep update mutation using variables
+### **Example**: Update mutation on deeply nested post and link to an existing author using variables
 ```graphql
 mutation updateAuthor($patch: UpdateAuthorInput!) {
   updateAuthor(input: $patch) {
     author {
       id
-      post {
+      posts {
         title
         text
       }


### PR DESCRIPTION
- There is no schema generated as Deep[Type] nor Deep[Type]Input, switched to add[Type] and Add[Type]Input
- Tweaked example titles for readability
- The edge `post` should have been `posts`